### PR TITLE
Add the official Lamplit Labs X link

### DIFF
--- a/components/shared/Footer.tsx
+++ b/components/shared/Footer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Logo } from "@/icons/logo";
-import { Github, Linkedin, Instagram } from "lucide-react";
+import { Github, Linkedin, Instagram, X } from "lucide-react";
 
 const products = [
     { label: "Kenntnistrainer", href: "https://www.kenntnistrainer.de" },
@@ -21,6 +21,7 @@ const navigation = [
 
 const socials = [
     { label: "GitHub", href: "https://github.com/lamplitlabs", icon: Github },
+    { label: "X", href: "https://x.com/lamplitlabs", icon: X },
     { label: "LinkedIn", href: "https://www.linkedin.com/company/lamplitlabs", icon: Linkedin },
     { label: "Instagram", href: "https://www.instagram.com/lamplitlabs", icon: Instagram },
 ];


### PR DESCRIPTION
## Summary
- add https://x.com/lamplitlabs exactly once to each existing organization social list touched in this repository
- leave unrelated content and repositories without social surfaces unchanged
- keep retired Mastodon and Threads account links absent

## Validation
- Production build passed